### PR TITLE
Try to find and use the product name (instead of the target name)

### DIFF
--- a/Sources/gen-ir/Compiler.swift
+++ b/Sources/gen-ir/Compiler.swift
@@ -20,4 +20,6 @@ struct CompilerCommand {
 }
 
 /// A mapping of targets to the commands used when building them
-typealias TargetsAndCommands = [String: [CompilerCommand]]
+typealias TargetToCommands = [String: [CompilerCommand]]
+///  A mapping of targets to their inferred product name
+typealias TargetToProduct = [String: String]

--- a/Sources/gen-ir/Extensions/String+Extension.swift
+++ b/Sources/gen-ir/Extensions/String+Extension.swift
@@ -27,6 +27,50 @@ extension String {
 	/// - Returns: The first index of the character found, or nil if it was not found
 	func firstIndexWithEscapes(of character: Character, from start: Index? = nil) -> Index? {
 		let startIndex = start ?? self.startIndex
+
+		return self[startIndex..<self.endIndex].firstIndexWithEscapes(of: character, from: startIndex)
+	}
+
+	/// Splits a String ignoring matches where a split would normally occur, but is escaped with a \ character
+	/// - Parameter separator: The separator to split on
+	/// - Returns: An array of subsequences, split from the collection's elements
+	func splitIgnoringEscapes(separator: Self.Element) -> [Self.SubSequence] {
+		var results: [Self.SubSequence] = []
+		var indices: [Self.Index] = []
+		var offset = self.startIndex
+
+		let substring = self[offset..<self.endIndex]
+
+		while let index = substring.firstIndexWithEscapes(of: separator, from: offset) {
+			indices.append(index)
+			offset = substring.index(after: index)
+		}
+
+		if indices.isEmpty {
+			// if no splits found, return the whole string as a single item array
+			return [substring]
+		}
+
+		var startIndex = self.startIndex
+
+		for index in indices {
+			results.append(self[startIndex..<index])
+			startIndex = index
+		}
+
+		return results
+	}
+}
+
+
+extension Substring {
+	/// Returns the first index of a character that hasn't been escaped
+	/// - Parameters:
+	///   - character: The character to search for
+	///   - start: The starting position in the string to search from
+	/// - Returns: The first index of the character found, or nil if it was not found
+	func firstIndexWithEscapes(of character: Character, from start: Index? = nil) -> Index? {
+		let startIndex = start ?? self.startIndex
 		var substring = self[startIndex..<self.endIndex]
 
 		while let index = substring.firstIndex(of: character) {

--- a/Sources/gen-ir/gen_ir.swift
+++ b/Sources/gen-ir/gen_ir.swift
@@ -64,7 +64,11 @@ struct IREmitterCommand: ParsableCommand {
 			try FileManager.default.createDirectory(at: output, withIntermediateDirectories: true)
 		}
 
-		let runner = CompilerCommandRunner(targetsAndCommands: parser.targetsAndCommands, output: output)
+		let runner = CompilerCommandRunner(
+			targetToCommands: parser.targetToCommands,
+			targetToProduct: parser.targetToProduct,
+			output: output
+		)
 
 		try runner.run()
 	}


### PR DESCRIPTION
This change parses log files for dSYM generation and tries to find and match a target to a product name, then uses the product name if avaliable to more closely match the IR output to the layout of an archive.