### PR TITLE
Silence a noisy print statement

### DIFF
--- a/Sources/gen-ir/XcodeLogParser.swift
+++ b/Sources/gen-ir/XcodeLogParser.swift
@@ -94,7 +94,7 @@ struct XcodeLogParser {
 			}
 
 			guard let currentTarget else {
-				logger.warning("No target was found for this command - \(line)")
+				logger.debug("No target was found for this command - \(line)")
 				continue
 			}
 


### PR DESCRIPTION
I did a silly and while reordering some statements forgot to change the log level of a print statement meaning a _lot_ of noise is generated during a run. Silence this noice behind the `--debug` flag.