### PR TITLE
Modify dynamic dependencies to include extras

### DIFF
--- a/Sources/GenIR/OutputPostprocessor.swift
+++ b/Sources/GenIR/OutputPostprocessor.swift
@@ -69,6 +69,9 @@ struct OutputPostprocessor {
 		}
 	}
 
+	/// Returns the base URL to start searching inside an xcarchive
+	/// - Parameter path: the original path, should be an xcarchive
+	/// - Returns: the path to start a dependency search from
 	static func baseSearchPath(startingAt path: URL) -> URL {
 		let productsPath = path.appendingPathComponent("Products")
 		let applicationsPath = productsPath.appendingPathComponent("Applications")


### PR DESCRIPTION
App Extensions, Watch Apps, Frameworks, etc are all listed as dependencies on the main app target (rightly so), but they're 'dynamic' for us in that they're not static - they are a target dependency, but not a runtime one. 

Don't attempt to move these dependencies into the main app target as they are separate and distinct units. 