### PR TITLE
Ignore resource bundles marked as native targets

### DIFF
--- a/PBXProjParser/Sources/PBXProjParser/Models/PBXTarget.swift
+++ b/PBXProjParser/Sources/PBXProjParser/Models/PBXTarget.swift
@@ -1,6 +1,6 @@
 //
 //  PBXTarget.swift
-//  
+//
 //
 //  Created by Thomas Hedderwick on 31/01/2023.
 //
@@ -11,8 +11,8 @@ class PBXTarget: PBXObject {
 	#if DEBUG
 	let buildConfigurationList: String
 	let comments: String?
-	let productName: String?
 	#endif
+	let productName: String?
 	let name: String
 	let dependencies: [String]
 
@@ -20,8 +20,8 @@ class PBXTarget: PBXObject {
 		#if DEBUG
 		case buildConfigurationList
 		case comments
-		case productName
 		#endif
+		case productName
 		case name
 		case dependencies
 
@@ -33,8 +33,8 @@ class PBXTarget: PBXObject {
 		#if DEBUG
 		buildConfigurationList = try container.decode(String.self, forKey: .buildConfigurationList)
 		comments = try container.decodeIfPresent(String.self, forKey: .comments)
-		productName = try container.decodeIfPresent(String.self, forKey: .productName)
 		#endif
+		productName = try container.decodeIfPresent(String.self, forKey: .productName)
 		name = try container.decode(String.self, forKey: .name)
 		dependencies = try container.decode([String].self, forKey: .dependencies)
 

--- a/PBXProjParser/Sources/PBXProjParser/Models/PBXTarget.swift
+++ b/PBXProjParser/Sources/PBXProjParser/Models/PBXTarget.swift
@@ -64,8 +64,8 @@ class PBXNativeTarget: PBXTarget {
 	#if DEBUG
 	let buildPhases: [String]
 	let productInstallPath: String?
-	let productType: String
 	#endif
+	let productType: String?
 	let productReference: String?
 	let packageProductDependencies: [String]
 
@@ -89,8 +89,8 @@ class PBXNativeTarget: PBXTarget {
 		#if DEBUG
 		case buildPhases
 		case productInstallPath
-		case productType
 		#endif
+		case productType
 		case productReference
 		case packageProductDependencies
 	}
@@ -101,8 +101,8 @@ class PBXNativeTarget: PBXTarget {
 		#if DEBUG
 		buildPhases = try container.decode([String].self, forKey: .buildPhases)
 		productInstallPath = try container.decodeIfPresent(String.self, forKey: .productInstallPath)
-		productType = try container.decode(String.self, forKey: .productType)
 		#endif
+		productType = try container.decodeIfPresent(String.self, forKey: .productType)
 		productReference = try container.decodeIfPresent(String.self, forKey: .productReference)
 		packageProductDependencies = try container.decodeIfPresent([String].self, forKey: .packageProductDependencies) ?? []
 
@@ -119,7 +119,7 @@ extension PBXNativeTarget: CustomStringConvertible {
 	var description: String {
 		"""
 		<PBXNativeTarget: BuildPhases: \(buildPhases), productInstallPath: \(productInstallPath ?? "nil") \
-		productReference: \(productReference ?? "nil"), productType: \(productType), \
+		productReference: \(productReference ?? "nil"), productType: \(productType ?? "nil"), \
 		packageProductDependencies: \(packageProductDependencies)>
 		"""
 	}

--- a/PBXProjParser/Sources/PBXProjParser/XcodeProject.swift
+++ b/PBXProjParser/Sources/PBXProjParser/XcodeProject.swift
@@ -1,6 +1,6 @@
 //
 //  XcodeProject.swift
-//  
+//
 //
 //  Created by Thomas Hedderwick on 27/01/2023.
 //
@@ -34,29 +34,32 @@ public struct XcodeProject {
 		model = try PBXProj.contentsOf(path.appendingPathComponent("project.pbxproj"))
 		project = try model.project()
 
-		targets = (model.objects(for: project.targets) as [PBXNativeTarget])
-			.reduce(into: [String: PBXNativeTarget](), { partialResult, target in
-				// Cocoapods likes to insert resource bundles as native targets. On iOS resource bundles
-				// cannot contain executables, therefore we should ignore them - IR will never be generated for them.
-				if let type = target.productType, type == "com.apple.product-type.bundle" {
-					logger.debug("Skipping bundle target: \(target.name)")
-				} else {
-					// TODO: For now, this is fine - but really we should centralize all this target naming stuff into `Target`
-					partialResult[target.name] = target
+		let projectTargets: [PBXNativeTarget] = model.objects(for: project.targets)
+		for target in projectTargets {
+			// Cocoapods likes to insert resource bundles as native targets. On iOS resource bundles
+			// cannot contain executables, therefore we should ignore them - IR will never be generated for them.
+			guard target.productType != "com.apple.product-type.bundle" else {
+				logger.debug("Skipping bundle target: \(target.name)")
+				continue
+			}
 
-					if let productName = target.productName {
-						partialResult[productName] = target
-					}
-				}
+			targets[target.name] = target
 
-				if let path = self.path(for: target, removeExtension: true) {
-					if partialResult[path] != nil {
-						logger.error("Clash in path name (\(path)) for target: \(target.name). Please report this issue.")
+			if let productName = target.productName {
+				targets[productName] = target
+			}
+
+		// TODO: For now, this is fine - but really we should centralize all this target naming stuff into `Target`
+			if let path = self.path(for: target, removeExtension: true) {
+					if targets[path] != nil {
+						if target.name != path || target.productName != path {
+							logger.debug("Clash in path name (\(path)) for target: \(target.name).")
+						}
 					} else {
-						partialResult[path] = target
+						targets[path] = target
 					}
 				}
-			})
+		}
 
 		// First pass - get all the direct dependencies
 		targets.values.forEach { determineDirectDependencies($0) }
@@ -173,7 +176,7 @@ public struct XcodeProject {
 		if removeExtension, let index = path.firstIndex(of: ".") {
 			path = String(path[path.startIndex..<index])
 		}
-		
+
 		return path
 	}
 }

--- a/PBXProjParser/Sources/PBXProjParser/XcodeProject.swift
+++ b/PBXProjParser/Sources/PBXProjParser/XcodeProject.swift
@@ -40,7 +40,16 @@ public struct XcodeProject {
 				// cannot contain executables, therefore we should ignore them - IR will never be generated for them.
 				if let type = target.productType, type == "com.apple.product-type.bundle" {
 					logger.debug("Skipping bundle target: \(target.name)")
-				} else if let path = self.path(for: target, removeExtension: true) {
+				} else {
+					// TODO: For now, this is fine - but really we should centralize all this target naming stuff into `Target`
+					partialResult[target.name] = target
+
+					if let productName = target.productName {
+						partialResult[productName] = target
+					}
+				}
+
+				if let path = self.path(for: target, removeExtension: true) {
 					if partialResult[path] != nil {
 						logger.error("Clash in path name (\(path)) for target: \(target.name). Please report this issue.")
 					} else {

--- a/Sources/GenIR/XcodeLogParser.swift
+++ b/Sources/GenIR/XcodeLogParser.swift
@@ -77,7 +77,6 @@ class XcodeLogParser {
 			}
 
 			guard let currentTarget else {
-				logger.debug("No target was found for this command - \(line)")
 				continue
 			}
 
@@ -108,8 +107,6 @@ class XcodeLogParser {
 		while lines.indices.contains(offset) {
 			let previousLine = lines[offset].trimmingCharacters(in: .whitespacesAndNewlines)
 			offset -= 1
-
-			logger.debug("Looking at previous line: \(previousLine)")
 
 			if previousLine.isEmpty {
 				// hit the top of the block, exit loop


### PR DESCRIPTION
This change addresses an issue where we see a resource `.bundle` marked as a `PBXNativeTarget` that shares the product and target name of another native target in the pbxproj. This appears to mostly be caused by cocoapods as Xcode doesn't use `PBXNativeTarget` to represent resource bundles usually. 