### PR TITLE
Fix for Swift 5.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: macos-12
     # This doesn't seem to work, even when the internet seems to indicate it should...
     env:
-      DEVELOPER_DIR: /Applications/Xcode_14.0.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_14.2.app/Contents/Developer
     steps:
       - uses: actions/checkout@v3
 
       - name: 🔨 Build
         run: |
-          sudo xcode-select -s /Applications/Xcode_14.0.app/
+          sudo xcode-select -s /Applications/Xcode_14.2.app/
           swift build

--- a/PBXProjParser/Sources/PBXProjParser/Models/PBXProj.swift
+++ b/PBXProjParser/Sources/PBXProjParser/Models/PBXProj.swift
@@ -71,7 +71,7 @@ class PBXProj: Decodable {
 }
 
 extension PBXProj {
-	func object<T>(forKey key: String, as type: T.Type = T.Type) -> T? {
+	func object<T>(forKey key: String, as type: T.Type = T.self) -> T? {
 		objects[key]?.unwrap() as? T
 	}
 

--- a/Sources/GenIR/Versions.swift
+++ b/Sources/GenIR/Versions.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 enum Versions {
-	static let version = "0.3.4"
+	static let version = "0.3.5"
 }


### PR DESCRIPTION
Looks like I bungled a metatype declaration, and Swift 5.8 catches it but <5.8 doesn't.