### PR TITLE
Address regression in output naming

### DIFF
--- a/PBXProjParser/Sources/PBXProjParser/Models/PBXBuildFile.swift
+++ b/PBXProjParser/Sources/PBXProjParser/Models/PBXBuildFile.swift
@@ -9,11 +9,11 @@ import Foundation
 
 public class PBXBuildFile: PBXObject {
 #if FULL_PBX_PARSING
-	let fileRef: String?
-	let platformFilter: String?
-	let platformFilters: [String]?
-	let productRef: String?
-	let settings: [String: Any]?
+	public let fileRef: String?
+	public let platformFilter: String?
+	public let platformFilters: [String]?
+	public let productRef: String?
+	public let settings: [String: Any]?
 
 	private enum CodingKeys: String, CodingKey {
 		case fileRef

--- a/PBXProjParser/Sources/PBXProjParser/Models/PBXBuildPhase.swift
+++ b/PBXProjParser/Sources/PBXProjParser/Models/PBXBuildPhase.swift
@@ -9,10 +9,10 @@ import Foundation
 
 public class PBXBuildPhase: PBXObject {
 #if FULL_PBX_PARSING
-	let alwaysOutOfDate: String?
-	let buildActionMask: UInt32
-	let files: [String]
-	let runOnlyForDeploymentPostprocessing: Int
+	public let alwaysOutOfDate: String?
+	public let buildActionMask: UInt32
+	public let files: [String]
+	public let runOnlyForDeploymentPostprocessing: Int
 
 	private enum CodingKeys: String, CodingKey {
 		case alwaysOutOfDate

--- a/PBXProjParser/Sources/PBXProjParser/Models/PBXContainerItemProxy.swift
+++ b/PBXProjParser/Sources/PBXProjParser/Models/PBXContainerItemProxy.swift
@@ -9,11 +9,11 @@ import Foundation
 
 public class PBXContainerItemProxy: PBXObject {
 	#if FULL_PBX_PARSING
-	let containerPortal: String
-	let proxyType: String
-	let remoteInfo: String
+	public let containerPortal: String
+	public let proxyType: String
+	public let remoteInfo: String
 	#endif
-	let remoteGlobalIDString: String
+	public let remoteGlobalIDString: String
 
 	private enum CodingKeys: String, CodingKey {
 		#if FULL_PBX_PARSING

--- a/PBXProjParser/Sources/PBXProjParser/Models/PBXFileReference.swift
+++ b/PBXProjParser/Sources/PBXProjParser/Models/PBXFileReference.swift
@@ -9,14 +9,14 @@ import Foundation
 
 public class PBXFileReference: PBXObject {
 	#if FULL_PBX_PARSING
-	let fileEncoding: String?
-	let explicitFileType: String?
-	let includeInIndex: String?
-	let lastKnownFileType: String?
-	let name: String?
-	let sourceTree: String
+	public let fileEncoding: String?
+	public let explicitFileType: String?
+	public let includeInIndex: String?
+	public let lastKnownFileType: String?
+	public let name: String?
+	public let sourceTree: String
 	#endif
-	let path: String
+	public let path: String
 
 	private enum CodingKeys: String, CodingKey {
 		#if FULL_PBX_PARSING

--- a/PBXProjParser/Sources/PBXProjParser/Models/PBXGroup.swift
+++ b/PBXProjParser/Sources/PBXProjParser/Models/PBXGroup.swift
@@ -9,9 +9,9 @@ import Foundation
 
 public class PBXGroup: PBXObject {
 #if FULL_PBX_PARSING
-	let children: [String]
-	let name: String?
-	let sourceTree: String
+	public let children: [String]
+	public let name: String?
+	public let sourceTree: String
 
 	private enum CodingKeys: String, CodingKey {
 		case children

--- a/PBXProjParser/Sources/PBXProjParser/Models/PBXObject.swift
+++ b/PBXProjParser/Sources/PBXProjParser/Models/PBXObject.swift
@@ -75,31 +75,31 @@ public enum PBXObjectType: String, Decodable, CaseIterable {
 	// swiftlint:disable cyclomatic_complexity
 	public func getType() -> PBXObject.Type {
 		switch self {
-		case .buildFile:						return PBXBuildFile.self
-		case .appleScriptBuildPhase:				return PBXAppleScriptBuildPhase.self
-		case .copyFilesBuildPhase:					return PBXCopyFilesBuildPhase.self
-		case .frameworksBuildPhase:					return PBXFrameworksBuildPhase.self
-		case .headersBuildPhase:						return PBXHeadersBuildPhase.self
-		case .resourcesBuildPhase:					return PBXResourcesBuildPhase.self
-		case .shellScriptBuildPhase:				return PBXShellScriptBuildPhase.self
-		case .sourcesBuildPhase:						return PBXSourcesBuildPhase.self
-		case .containerItemProxy:						return PBXContainerItemProxy.self
-		case .fileReference:								return PBXFileReference.self
-		case .group:												return PBXGroup.self
-		case .variantGroup:									return PBXVariantGroup.self
-		case .aggregateTarget:							return PBXAggregateTarget.self
-		case .legacyTarget:									return PBXLegacyTarget.self
-		case .nativeTarget:									return PBXNativeTarget.self
-		case .project:											return PBXProject.self
-		case .targetDependency:							return PBXTargetDependency.self
-		case .buildConfiguration:						return XCBuildConfiguration.self
-		case .configurationList:						return XCConfigurationList.self
+		case .buildFile:											return PBXBuildFile.self
+		case .appleScriptBuildPhase:					return PBXAppleScriptBuildPhase.self
+		case .copyFilesBuildPhase:						return PBXCopyFilesBuildPhase.self
+		case .frameworksBuildPhase:						return PBXFrameworksBuildPhase.self
+		case .headersBuildPhase:							return PBXHeadersBuildPhase.self
+		case .resourcesBuildPhase:						return PBXResourcesBuildPhase.self
+		case .shellScriptBuildPhase:					return PBXShellScriptBuildPhase.self
+		case .sourcesBuildPhase:							return PBXSourcesBuildPhase.self
+		case .containerItemProxy:							return PBXContainerItemProxy.self
+		case .fileReference:									return PBXFileReference.self
+		case .group:													return PBXGroup.self
+		case .variantGroup:										return PBXVariantGroup.self
+		case .aggregateTarget:								return PBXAggregateTarget.self
+		case .legacyTarget:										return PBXLegacyTarget.self
+		case .nativeTarget:										return PBXNativeTarget.self
+		case .project:												return PBXProject.self
+		case .targetDependency:								return PBXTargetDependency.self
+		case .buildConfiguration:							return XCBuildConfiguration.self
+		case .configurationList:							return XCConfigurationList.self
 		case .swiftPackageProductDependency:	return XCSwiftPackageProductDependency.self
-		case .remoteSwiftPackageReference:	return XCRemoteSwiftPackageReference.self
-		case .referenceProxy:								return PBXReferenceProxy.self
-		case .versionGroup:									return XCVersionGroup.self
-		case .buildRule:										return PBXBuildRule.self
-		case .rezBuildPhase:								return PBXRezBuildPhase.self
+		case .remoteSwiftPackageReference:		return XCRemoteSwiftPackageReference.self
+		case .referenceProxy:									return PBXReferenceProxy.self
+		case .versionGroup:										return XCVersionGroup.self
+		case .buildRule:											return PBXBuildRule.self
+		case .rezBuildPhase:									return PBXRezBuildPhase.self
 		}
 		// swiftlint:enable cyclomatic_complexity
 	}

--- a/PBXProjParser/Sources/PBXProjParser/Models/PBXProj.swift
+++ b/PBXProjParser/Sources/PBXProjParser/Models/PBXProj.swift
@@ -70,7 +70,7 @@ public class PBXProj: Decodable {
 	}
 }
 
-extension PBXProj {
+public extension PBXProj {
 	func object<T>(forKey key: String, as type: T.Type = T.self) -> T? {
 		objects[key]?.unwrap() as? T
 	}

--- a/PBXProjParser/Sources/PBXProjParser/Models/PBXProject.swift
+++ b/PBXProjParser/Sources/PBXProjParser/Models/PBXProject.swift
@@ -8,21 +8,21 @@
 import Foundation
 
 public class PBXProject: PBXObject {
-#if FULL_PBX_PARSING
-	let attributes: [String: Any]
-	let buildConfigurationList: String
-	let compatibilityVersion: String
-	let developmentRegion: String
-	let hasScannedForEncodings: String
-	let knownRegions: [String]
-	let mainGroup: String
-	let productRefGroup: String
-	let projectDirPath: String
-	let projectReferences: [[String: String]]?
-	let projectRoot: String
-#endif
-	let packageReferences: [String]
-	let targets: [String] /// Hold references to targets via their identifiers
+	#if FULL_PBX_PARSING
+	public let attributes: [String: Any]
+	public let buildConfigurationList: String
+	public let compatibilityVersion: String
+	public let developmentRegion: String
+	public let hasScannedForEncodings: String
+	public let knownRegions: [String]
+	public let mainGroup: String
+	public let productRefGroup: String
+	public let projectDirPath: String
+	public let projectReferences: [[String: String]]?
+	public let projectRoot: String
+	#endif
+	public let packageReferences: [String]
+	public let targets: [String] /// Hold references to targets via their identifiers
 
 	private enum CodingKeys: String, CodingKey {
 		case attributes

--- a/PBXProjParser/Sources/PBXProjParser/Models/PBXTarget.swift
+++ b/PBXProjParser/Sources/PBXProjParser/Models/PBXTarget.swift
@@ -43,7 +43,7 @@ public class PBXTarget: PBXObject {
 }
 
 public class PBXAggregateTarget: PBXTarget {
-	let buildPhases: [String]
+	public let buildPhases: [String]
 
 	private enum CodingKeys: String, CodingKey {
 		case buildPhases
@@ -62,20 +62,20 @@ public class PBXLegacyTarget: PBXTarget {}
 
 public class PBXNativeTarget: PBXTarget {
 	#if FULL_PBX_PARSING
-	let buildPhases: [String]
-	let productInstallPath: String?
+	public let buildPhases: [String]
+	public let productInstallPath: String?
 	#endif
-	let productType: String?
-	let productReference: String?
-	let packageProductDependencies: [String]
+	public let productType: String?
+	public let productReference: String?
+	public let packageProductDependencies: [String]
 
 	private(set) var targetDependencies: [String: TargetDependency] = [:]
 
-	enum TargetDependency {
+	public enum TargetDependency {
 		case native(PBXNativeTarget)
 		case package(XCSwiftPackageProductDependency)
 
-		var name: String {
+		public var name: String {
 			switch self {
 			case .native(let target):
 				return target.name
@@ -132,7 +132,7 @@ extension PBXNativeTarget: Equatable {
 
 #if FULL_PBX_PARSING
 extension PBXNativeTarget: CustomStringConvertible {
-	var description: String {
+	public var description: String {
 		"""
 		<PBXNativeTarget: BuildPhases: \(buildPhases), productInstallPath: \(productInstallPath ?? "nil") \
 		productReference: \(productReference ?? "nil"), productType: \(productType ?? "nil"), \
@@ -143,8 +143,8 @@ extension PBXNativeTarget: CustomStringConvertible {
 #endif
 
 public class PBXTargetDependency: PBXObject {
-	let target: String?
-	let targetProxy: String?
+	public let target: String?
+	public let targetProxy: String?
 
 	private enum CodingKeys: String, CodingKey {
 		case target

--- a/PBXProjParser/Sources/PBXProjParser/Models/PBXVariantGroup.swift
+++ b/PBXProjParser/Sources/PBXProjParser/Models/PBXVariantGroup.swift
@@ -9,9 +9,9 @@ import Foundation
 
 public class PBXVariantGroup: PBXObject {
 	#if FULL_PBX_PARSING
-	let children: [String]
-	let name: String
-	let sourceTree: String
+	public let children: [String]
+	public let name: String
+	public let sourceTree: String
 
 	private enum CodingKeys: String, CodingKey {
 		case children

--- a/PBXProjParser/Sources/PBXProjParser/Models/XCBuildConfiguration.swift
+++ b/PBXProjParser/Sources/PBXProjParser/Models/XCBuildConfiguration.swift
@@ -9,9 +9,9 @@ import Foundation
 
 public class XCBuildConfiguration: PBXObject {
 	#if FULL_PBX_PARSING
-	var baseConfigurationReference: String?
-	var buildSettings: [String: Any]
-	var name: String
+	public var baseConfigurationReference: String?
+	public var buildSettings: [String: Any]
+	public var name: String
 
 	private enum CodingKeys: String, CodingKey {
 		case baseConfigurationReference

--- a/PBXProjParser/Sources/PBXProjParser/Models/XCConfigurationList.swift
+++ b/PBXProjParser/Sources/PBXProjParser/Models/XCConfigurationList.swift
@@ -9,9 +9,9 @@ import Foundation
 
 public class XCConfigurationList: PBXObject {
 	#if FULL_PBX_PARSING
-	let buildConfigurations: [String]
-	let defaultConfigurationIsVisible: String
-	let defaultConfigurationName: String
+	public let buildConfigurations: [String]
+	public let defaultConfigurationIsVisible: String
+	public let defaultConfigurationName: String
 
 	private enum CodingKeys: String, CodingKey {
 		case buildConfigurations

--- a/PBXProjParser/Sources/PBXProjParser/ProjectParser.swift
+++ b/PBXProjParser/Sources/PBXProjParser/ProjectParser.swift
@@ -73,7 +73,7 @@ public struct ProjectParser {
 					"""
 					Failed to find a target: \(target) in project: \(project.path). \
 					Possible targets: \(project.targets.map { ($0.name, $0.productName ?? "nil")}). \
-					Possible Packages: \(project.packages.map { $0.productName} )
+					Possible Packages: \(project.packages.map { $0.productName})
 					"""
 				)
 			}
@@ -100,5 +100,12 @@ public struct ProjectParser {
 		case .project(let project):				return project
 		case .workspace(let workspace):	return workspace.targetsToProject[target]
 		}
+	}
+
+	/// Gets the project model for a given target
+	/// - Parameter target: the target to search for
+	/// - Returns: a `PBXProj` that represents the pbxproj this target is a part of, if one was found
+	public func model(for target: String) -> PBXProj? {
+		project(for: target)?.model
 	}
 }

--- a/PBXProjParser/Sources/PBXProjParser/XcodeProject.swift
+++ b/PBXProjParser/Sources/PBXProjParser/XcodeProject.swift
@@ -18,7 +18,7 @@ public struct XcodeProject {
 	public let path: URL
 
 	/// The underlying pbxproj model
-	private let model: PBXProj
+	public let model: PBXProj
 
 	/// The 'project' object for the pbxproj
 	let project: PBXProject
@@ -45,7 +45,7 @@ public struct XcodeProject {
 				$0.productType != "com.apple.product-type.bundle"
 			}
 
-		packages = model.objects(for: project.packageReferences)
+		packages = model.objects(of: .swiftPackageProductDependency, as: XCSwiftPackageProductDependency.self)
 
 		// First pass - get all the direct dependencies
 		targets.forEach { determineDirectDependencies($0) }

--- a/Sources/GenIR/OutputPostprocessor.swift
+++ b/Sources/GenIR/OutputPostprocessor.swift
@@ -46,7 +46,7 @@ struct OutputPostprocessor {
 
 		let pathsToRemove = try targets.flatMap { target in
 			guard let path = targetsToPaths[target] else {
-				logger.error("Failed to get path for target: \(target)")
+				logger.error("Couldn't find path for target: \(target)")
 				return Set<URL>()
 			}
 

--- a/Sources/GenIR/Targets/Target.swift
+++ b/Sources/GenIR/Targets/Target.swift
@@ -42,21 +42,60 @@ class Target {
 	/// A list of dependencies of this Target
 	private(set) var dependencies: [String] = []
 
+	let project: ProjectParser?
+
 	/// The name to use when writing IR to disk, prefer the product name if possible.
 	var nameForOutput: String {
-		productName ?? name
+		switch backingTarget {
+		case .native(let target):
+			return path(for: target) ?? productName ?? name
+		case .packageDependency, .none:
+			return productName ?? name
+		}
+	}
+
+	/// Gets the path for native targets
+	var path: String? {
+		switch backingTarget {
+		case .native(let target):
+			return path(for: target)
+		case .packageDependency, .none:
+			return nil
+		}
 	}
 
 	init(
 		name: String,
 		backingTarget: BackingTarget? = nil,
 		commands: [CompilerCommand] = [],
-		dependencies: [String] = []
+		dependencies: [String] = [],
+		project: ProjectParser? = nil
 	) {
 		self.name = name
 		self.backingTarget = backingTarget
 		self.commands = commands
 		self.dependencies = dependencies
+		self.project = project
+	}
+
+	/// Gets the 'path' (normally the name of the target's product) for a given target
+	private func path(for target: PBXNativeTarget) -> String? {
+		guard let model = project?.model(for: target.name) else {
+			logger.debug("Failed to get model for target: \(target)")
+			return nil
+		}
+
+		guard let productReference = target.productReference else {
+			logger.debug("Failed to get product reference for target: \(target). Possibly a SPM Package description?")
+			return nil
+		}
+
+		guard let reference = model.object(forKey: productReference, as: PBXFileReference.self) else {
+			logger.error("Failed to get object for target productReference: \(productReference)")
+			return nil
+		}
+
+		return (reference.path as NSString).lastPathComponent as String
 	}
 }
 

--- a/Sources/GenIR/Targets/Targets.swift
+++ b/Sources/GenIR/Targets/Targets.swift
@@ -36,7 +36,8 @@ struct Targets {
 	mutating func insert(native target: PBXNativeTarget) -> (inserted: Bool, memberAfterInsert: Element) {
 		let newTarget = Target(
 				name: target.name,
-				backingTarget: .native(target)
+				backingTarget: .native(target),
+				project: project
 			)
 
 		return targets.insert(newTarget)
@@ -50,7 +51,8 @@ struct Targets {
 		// TODO: when we can handle SPM transitive deps, should we look up the name here? Can we even do that?
 		let newTarget = Target(
 				name: target.productName,
-				backingTarget: .packageDependency(target)
+				backingTarget: .packageDependency(target),
+				project: project
 			)
 
 		return targets.insert(newTarget)
@@ -71,6 +73,8 @@ struct Targets {
 			if target.name == key {
 				return target
 			} else if target.productName == key {
+				return target
+			} else if target.path == key {
 				return target
 			}
 		}

--- a/Tests/GenIRTests/gen_irTests.swift
+++ b/Tests/GenIRTests/gen_irTests.swift
@@ -4,7 +4,12 @@ import PBXProjParser
 
 final class GenIRTests: XCTestCase {
 	func testManyTargetTestTargets() throws {
-		let projectPath = "TestAssets/ManyTargetTest/ManyTargetTest.xcodeproj".fileURL
+		// HACK: use the #file magic to get a path to the test case... Maybe there's a better way to do this?
+		let packageRoot = URL(fileURLWithPath: #file.replacingOccurrences(of: "Tests/GenIRTests/gen_irTests.swift", with: ""))
+		let projectPath = packageRoot
+			.appendingPathComponent("TestAssets")
+			.appendingPathComponent("ManyTargetTest")
+			.appendingPathComponent("ManyTargetTest.xcodeproj")
 		let project = try ProjectParser(path: projectPath, logLevel: logger.logLevel)
 		var targets = Targets(for: project)
 


### PR DESCRIPTION
This change addresses a regression in output naming introduced in #24 by reconfiguring the 'path' method of using build file path references for on-disk filenames and fixing an issue in swift package loading that resulted in less swift package dependencies being found.