### PR TITLE
Use the correct substring index for guarding against OoB errors

### DIFF
--- a/Sources/GenIR/Extensions/String+Extension.swift
+++ b/Sources/GenIR/Extensions/String+Extension.swift
@@ -1,6 +1,6 @@
 //
 //  String+Extension.swift
-//  
+//
 //
 //  Created by Thomas Hedderwick on 04/07/2022.
 //
@@ -83,7 +83,7 @@ extension Substring {
 		var substring = self[startIndex..<self.endIndex]
 
 		while let index = substring.firstIndex(of: character) {
-			guard index != startIndex else {
+			guard index != substring.startIndex else {
 				return index
 			}
 


### PR DESCRIPTION
Use the start index of the newly created substring slice instead of the start index of the initial substring when calculating index ranges.