### PR TITLE
Remove testing logic in the BuildCacheManipulator

### DIFF
--- a/Sources/GenIR/BuildCacheManipulator.swift
+++ b/Sources/GenIR/BuildCacheManipulator.swift
@@ -22,7 +22,7 @@ struct BuildCacheManipulator {
 		self.buildCachePath = buildCachePath
 		self.buildSettings = buildSettings
 		buildProductsPath = archive
-		shouldDeploySkipInstallHack = buildSettings["SKIP_INSTALL"] == "NO" || true
+		shouldDeploySkipInstallHack = buildSettings["SKIP_INSTALL"] == "NO"
 
 		guard FileManager.default.directoryExists(at: buildCachePath) else {
 			throw Error.directoryNotFound("Build cache path doesn't exist at expected path: \(buildCachePath)")


### PR DESCRIPTION
Removes a logic error in the BuildCacheManipulator to make it run _only_ when `SKIP_INSTALL=NO` is set

Resolves #36 