### PR TITLE
Xcode 16 Support

### DIFF
--- a/PIF/Sources/PIFSupport/PIF.swift
+++ b/PIF/Sources/PIFSupport/PIF.swift
@@ -436,6 +436,7 @@ public enum PIF {
 			case hostBuild = "com.apple.product-type.tool.host-build"
 			case xpcService = "com.apple.product-type.xpc-service"
 			case watchApp2 = "com.apple.product-type.application.watchapp2"
+			case watchApp2Container = "com.apple.product-type.application.watchapp2-container"
 			case watchKit2Extension = "com.apple.product-type.watchkit2-extension"
 		}
 

--- a/Sources/GenIR/Extensions/Process+Extension.swift
+++ b/Sources/GenIR/Extensions/Process+Extension.swift
@@ -118,8 +118,8 @@ extension Process {
 		try? stderrHandle.close()
 
 		return .init(
-			stdout: String(decoding: stdout, as: UTF8.self),
-			stderr: String(decoding: stderr, as: UTF8.self),
+			stdout: String(data: stdout, encoding: .utf8),
+			stderr: String(data: stderr, encoding: .utf8),
 			code: process.terminationStatus
 		)
 	}

--- a/Sources/GenIR/Extensions/String+Extension.swift
+++ b/Sources/GenIR/Extensions/String+Extension.swift
@@ -118,3 +118,10 @@ extension [String] {
 		return nil
 	}
 }
+
+extension StringProtocol {
+	/// Trims leading and trailing whitespace characters
+	func trimmed() -> String {
+		return trimmingCharacters(in: .whitespacesAndNewlines)
+	}
+}


### PR DESCRIPTION
There were some issues parsing Objective-C build logs from the Xcode 16.0 Beta, so the `XcodeLogParser` has been reworked to address that. With these changes the parser will no longer attempt to backtrack while searching for build commands, so there is a significant performance increase as well.