### PR TITLE
Fix SwiftLint Job

### DIFF
--- a/.github/workflows/SwiftLint.yml
+++ b/.github/workflows/SwiftLint.yml
@@ -2,17 +2,14 @@ name: SwiftLint
 
 on:
   pull_request:
-    paths:
-      - '.github/workflows/swiftlint.yml'
-      - '.swiftlint.yml'
-      - '**/*.swift'
+    branches: ['main']
 
 jobs:
+  # Runs swiftlint on any pull request to main (note: this runs for _all_ files, not only the changed files in the PR!)
   SwiftLint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - name: Lint changed files
-        uses: norio-nomura/action-swiftlint@3.2.1
-        env:
-          DIFF_BASE: ${{ github.base_ref }}
+      - uses: actions/checkout@v4
+      - uses: cirruslabs/swiftlint-action@v1
+        with:
+          version: latest

--- a/PIF/Sources/PIFSupport/PIF.swift
+++ b/PIF/Sources/PIFSupport/PIF.swift
@@ -15,7 +15,7 @@
 	- adjust types to remove external dependencies on SPM
 */
 
-// swiftlint:disable file_length type_body_length
+// swiftlint:disable file_length type_body_length static_over_final_class
 import Foundation
 
 /// The Project Interchange Format (PIF) is a structured representation of the
@@ -900,4 +900,4 @@ private struct UntypedTarget: Decodable {
 	}
 	let contents: TargetContents
 }
-// swiftlint:enable file_length type_body_length
+// swiftlint:enable file_length type_body_length static_over_final_class

--- a/Sources/GenIR/CompilerCommandRunner.swift
+++ b/Sources/GenIR/CompilerCommandRunner.swift
@@ -78,6 +78,7 @@ struct CompilerCommandRunner {
 	///   - name: The name this command relates to, used to create the product folder
 	///   - directory: The directory to run these commands in
 	/// - Returns: The total amount of modules produced for this target
+	// swiftlint:disable:next function_body_length
 	private func run(commands: [CompilerCommand], for name: String, at directory: URL) throws -> Int {
 		let targetDirectory = directory.appendingPathComponent(name)
 

--- a/Sources/GenIR/Extensions/Process+Extension.swift
+++ b/Sources/GenIR/Extensions/Process+Extension.swift
@@ -118,8 +118,8 @@ extension Process {
 		try? stderrHandle.close()
 
 		return .init(
-			stdout: String(data: stdout, encoding: .utf8),
-			stderr: String(data: stderr, encoding: .utf8),
+			stdout: String(decoding: stdout, as: UTF8.self),
+			stderr: String(decoding: stderr, as: UTF8.self),
 			code: process.terminationStatus
 		)
 	}

--- a/Sources/GenIR/XcodeLogParser.swift
+++ b/Sources/GenIR/XcodeLogParser.swift
@@ -70,6 +70,7 @@ class XcodeLogParser {
 	/// Parses an array representing the contents of an Xcode build log
 	/// - Parameters:
 	///   - lines: contents of the Xcode build log lines
+	// swiftlint:disable:next cyclomatic_complexity
 	private func parseBuildLog(_ lines: [String]) {
 		var currentTarget: String?
 		var seenTargets = Set<String>()


### PR DESCRIPTION
This change swaps out the underlying action for the SwiftLint job to a more maintained version and address the current violations.

It should be noted - this also changes the behaviour to lint _all_ files not just changed files. This will better cover misses that were introduced.