### PR TITLE
Restore support for Xcode 14

### DIFF
--- a/PIF/Package.swift
+++ b/PIF/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 5.7
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Sources/GenIR/Extensions/Process+Extension.swift
+++ b/Sources/GenIR/Extensions/Process+Extension.swift
@@ -23,16 +23,16 @@ extension Process {
 		///   - stderr: the standard error
 		///   - code: the exit code
 		init(stdout: String?, stderr: String?, code: Int32) {
-			self.stdout = if let stdout, stdout.isEmpty {
-				nil
+			if let stdout, stdout.isEmpty {
+				self.stdout = nil
 			} else {
-				stdout
+				self.stdout = stdout
 			}
 
-			self.stderr = if let stderr, stderr.isEmpty {
-				nil
+			if let stderr, stderr.isEmpty {
+				self.stderr = nil
 			} else {
-				stderr
+				self.stderr = stderr
 			}
 
 			self.code = code

--- a/Sources/GenIR/Target.swift
+++ b/Sources/GenIR/Target.swift
@@ -36,17 +36,17 @@ class Target {
 	init(from baseTarget: PIF.BaseTarget) {
 		guid = baseTarget.guid
 		name = baseTarget.name
-		productName = if let target = baseTarget as? PIF.Target, !target.productName.isEmpty {
-			target.productName
+		if let target = baseTarget as? PIF.Target, !target.productName.isEmpty {
+			productName = target.productName
 		} else if baseTarget.guid == "PACKAGE-PRODUCT:\(baseTarget.name)" {
 			// The `PACKAGE-PRODUCT` for a package does not have a product reference name so
 			// we do not have a proper extension. For now we assume it is a framework and add
 			// the extension. A better way may be to follow the `dynamicTargetVariantGuid` of
 			// the `PACKAGE-TARGET` as this appears to provide the correct name if available.
-			baseTarget.name.appending(".framework")
+			productName = baseTarget.name.appending(".framework")
 		} else {
 			// Fallback to the target's name if we are unable to determine a proper product name.
-			baseTarget.name
+			productName = baseTarget.name
 		}
 		isBuildable = guid == "PACKAGE-TARGET:\(name)" || !guid.hasPrefix("PACKAGE-")
 		isPackageProduct = !guid.hasPrefix("PACKAGE-TARGET:")

--- a/Tests/GenIRTests/WorkspaceTests.swift
+++ b/Tests/GenIRTests/WorkspaceTests.swift
@@ -64,7 +64,7 @@ final class WorkspaceTests: XCTestCase {
 
 		// Check dependencies made it to the right place. All dependencies should be statically
 		// linked and appear under the .app directory.
-		let appIRPath = context.archive.appending(path: "IR/App.app/")
+		let appIRPath = context.archive.appendingPathComponent("IR/App.app/")
 
 		let expectedIRFiles = Self.appIRFiles
 			.union(Self.commonIRFiles)


### PR DESCRIPTION
 It looks like support for Xcode 14 was mistakenly removed from the v0.5.0 release. This appears to be related to the new `PIF` package that was introduced with a Swift version requirement of `5.10`.

Resolves #72 