### PR TITLE
Handle targets with same name but in different projects

### DIFF
--- a/Sources/GenIR/CompilerCommandRunner.swift
+++ b/Sources/GenIR/CompilerCommandRunner.swift
@@ -47,7 +47,7 @@ struct CompilerCommandRunner {
 
 	/// Starts the runner
 	/// - Parameter targets: the targets holding the commands to run
-	func run(targets: [Target], commands: [String: [CompilerCommand]]) throws {
+	func run(targets: [Target], commands: [TargetKey: [CompilerCommand]]) throws {
 		// Quick, do a hack!
 		try buildCacheManipulator.manipulate()
 
@@ -59,7 +59,7 @@ struct CompilerCommandRunner {
 		var totalModulesRun = 0
 
 		for target in targets.filter({ $0.isBuildable }) {
-			guard let targetCommands = commands[target.name] else {
+			guard let targetCommands = commands[TargetKey(projectName: target.projectName, targetName: target.name)] else {
 				continue
 			}
 

--- a/Sources/GenIR/Target.swift
+++ b/Sources/GenIR/Target.swift
@@ -9,6 +9,11 @@ import Foundation
 import PIFSupport
 import DependencyGraph
 
+struct TargetKey: Hashable {
+	let projectName: String
+	let targetName: String
+}
+
 /// Represents a product to build (app, framework, plugin, package). It contains the identifying
 /// information about a target and its output when it is built or archived. In the future the
 /// `PIF` package will likely be modified so that it is usable within the context of Gen-IR
@@ -18,6 +23,8 @@ class Target {
 	let guid: String
 	/// Name of the target.
 	let name: String
+	/// Name of the project that the target belongs to.
+	let projectName: String
 	/// The product name refers to the output of this target when it is built or copied into an archive.
 	let productName: String
 
@@ -33,9 +40,14 @@ class Target {
 
 	let isSwiftPackage: Bool
 
-	init(from baseTarget: PIF.BaseTarget) {
+	init(from baseTarget: PIF.BaseTarget, in project: PIF.Project) {
 		guid = baseTarget.guid
 		name = baseTarget.name
+		// Each target is associated with a project, but the name of the project is not
+		// always available. We fallback to the GUID to maintain uniqueness of the target,
+		// but this isn't useful for finding the target in the build log, since only
+		// the project name is present in there.
+		projectName = project.projectName ?? project.groupTree.name ?? project.guid
 		if let target = baseTarget as? PIF.Target, !target.productName.isEmpty {
 			productName = target.productName
 		} else if baseTarget.guid == "PACKAGE-PRODUCT:\(baseTarget.name)" {


### PR DESCRIPTION
It's possible for multiple projects to contain the same target name, but we only track targets in the build log by the target name. Because of this we will see duplicated bitcode files across _all_ targets with the same name. The solution implemented here is to track targets by both project name and target name in the build log as we do not have access to GUIDs there. We then use these names to map back to the appropriate PIF targets.

The challenge is pulling the name of the project since it is not necessarily present in the PIF files, so we fallback to using the name of the root group node in the project. I am not sure this is the 100% correct way to go, but I can't think of anything better at the moment.

Fixes #46 