### PR TITLE
Ignore test bundles when generating bitcode

### DIFF
--- a/Sources/GenIR/CompilerCommandRunner.swift
+++ b/Sources/GenIR/CompilerCommandRunner.swift
@@ -58,7 +58,7 @@ struct CompilerCommandRunner {
 
 		var totalModulesRun = 0
 
-		for target in targets.filter({ $0.isBuildable }) {
+		for target in targets {
 			guard let targetCommands = commands[TargetKey(projectName: target.projectName, targetName: target.name)] else {
 				continue
 			}

--- a/Sources/GenIR/GenIR.swift
+++ b/Sources/GenIR/GenIR.swift
@@ -112,9 +112,10 @@ let programName = CommandLine.arguments.first!
 
 		// Find and parse the PIF cache
 		let pifCache = try PIFCache(buildCache: log.buildCachePath)
+
 		let targets = pifCache.projects.flatMap { project in
 			project.targets.compactMap { Target(from: $0, in: project) }
-		}
+		}.filter { !$0.isTest }
 
 		let targetCommands = log.commandLog.reduce(into: [TargetKey: [CompilerCommand]]()) { commands, entry in
 			commands[entry.target, default: []].append(entry.command)

--- a/Sources/GenIR/Target.swift
+++ b/Sources/GenIR/Target.swift
@@ -32,6 +32,10 @@ class Target {
 	/// for the object file, since this is used by the other targets.
 	let isBuildable: Bool
 
+	/// Returns true if this target is a test bundle. These will be ignored when packaging bitcode
+	/// in order to reduce archive size.
+	let isTest: Bool
+
 	/// Returns true if this target produces a package product that will be included in the archive.
 	/// For simplicity we say this can be anything that is not a `PACKAGE-TARGET`, which will just be
 	/// an object file. The `dynamicTargetVariantGuid` of a `PACKAGE-TARGET` is technically a framework,
@@ -60,6 +64,13 @@ class Target {
 			// Fallback to the target's name if we are unable to determine a proper product name.
 			productName = baseTarget.name
 		}
+
+		if let target = baseTarget as? PIF.Target {
+			isTest = target.productType == .unitTest || target.productType == .uiTesting
+		} else {
+			isTest = false
+		}
+
 		isBuildable = guid == "PACKAGE-TARGET:\(name)" || !guid.hasPrefix("PACKAGE-")
 		isPackageProduct = !guid.hasPrefix("PACKAGE-TARGET:")
 		isSwiftPackage = guid.hasPrefix("PACKAGE-")

--- a/Tests/GenIRTests/MultipleAppTests.swift
+++ b/Tests/GenIRTests/MultipleAppTests.swift
@@ -18,7 +18,7 @@ final class MultipleAppTests: XCTestCase {
 		let app = try XCTUnwrap(targets.first(where: { $0.name == "MultipleApp" }))
 		let copy = try XCTUnwrap(targets.first(where: { $0.name == "MultipleApp Copy" }))
 
-        XCTAssertEqual(context.logParser.targetCommands[app.name]?.count, 3)
-        XCTAssertEqual(context.logParser.targetCommands[copy.name]?.count, 3)
+        XCTAssertEqual(context.logParser.targetCommands[app.name]?.count, 1)
+        XCTAssertEqual(context.logParser.targetCommands[copy.name]?.count, 1)
 	}
 }


### PR DESCRIPTION
We don't do anything with bitcode generated from test bundles, so by ignoring them we are able to greatly reduce the size of the IR directory.